### PR TITLE
Stop paste issue description to trello

### DIFF
--- a/client/trello.go
+++ b/client/trello.go
@@ -26,6 +26,8 @@ func (t *TrelloClient) CreateCard(title string, desc string) {
   err = list.AddCard(&trello.Card{ Name: title, Desc: desc }, trello.Defaults())
   if err != nil {
     log.Print(err)
+    log.Print("Card could not be created.")
+  } else {
+    log.Print("Card successfully created.")
   }
-  log.Print("Card successfully created.")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,12 +47,12 @@ func RootCmd() *cobra.Command {
         title, body := github_client.GetPrTitleAndBody(input_url)
         body = body + "\n" + "ref: " + input_url
         client := client.NewTrelloClient()
-        client.CreateCard(title, body)
+        client.CreateCard(title, "ref: " + input_url)
       } else if divided_url.Type == "issues" {
         title, body := github_client.GetIssueTitleAndBody(input_url)
         body = body + "\n" + "ref: " + input_url
         client := client.NewTrelloClient()
-        client.CreateCard(title, body)
+        client.CreateCard(title, "ref: " + input_url)
       }
     },
   }


### PR DESCRIPTION
Decided to stop send issue description to trello.
I realized this is not really useful at all. I just needed reference URL